### PR TITLE
Add Kubernetes initial configuration

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,0 +1,321 @@
+apiVersion: v1
+items:
+  # pgAdmin4 service
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: pgadmin
+      name: pgadmin
+    spec:
+      type: LoadBalancer
+      ports:
+        - name: "8484"
+          port: 8484
+          targetPort: 80
+      selector:
+        io.kompose.service: pgadmin
+    status:
+      loadBalancer: {}
+
+  # PostgreSQL database service
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: postgresql
+      name: postgresql
+    spec:
+      ports:
+        - name: "5432"
+          port: 5432
+          targetPort: 5432
+      selector:
+        io.kompose.service: postgresql
+    status:
+      loadBalancer: {}
+
+  # REST service
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: rest
+      name: rest
+    spec:
+      type: LoadBalancer
+      ports:
+        - name: "9000"
+          port: 9000
+          targetPort: 9000
+      selector:
+        io.kompose.service: rest
+    status:
+      loadBalancer: {}
+
+  # RUNONCE job
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: runonce
+      name: runonce
+    spec:
+      template:
+        spec:
+          containers:
+          - name: runonce
+            image: minerva_runonce
+          restartPolicy: Never
+      backoffLimit: 4
+
+  # USERS service
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: users
+      name: users
+    spec:
+      ports:
+        - name: "9010"
+          port: 9010
+          targetPort: 9010
+    status:
+      loadBalancer: {}
+
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: pgadmin
+      name: pgadmin
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          io.kompose.service: pgadmin
+      strategy: {}
+      template:
+        metadata:
+          annotations:
+            kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+            kompose.version: 1.26.0 (40646f47)
+          creationTimestamp: null
+          labels:
+            io.kompose.service: pgadmin
+        spec:
+          containers:
+            - env:
+                - name: GUNICORN_ACCESS_LOGFILE
+                  value: /dev/null
+                - name: PGADMIN_DEFAULT_EMAIL
+                  value: admin@admin.com
+                - name: PGADMIN_DEFAULT_PASSWORD
+                  value: admin
+              image: minerva_pgadmin
+              imagePullPolicy: Never
+              name: pgadmin
+              ports:
+                - containerPort: 80
+              resources: {}
+          restartPolicy: Always
+    status: {}
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: postgresql
+      name: postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          io.kompose.service: postgresql
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          annotations:
+            kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+            kompose.version: 1.26.0 (40646f47)
+          creationTimestamp: null
+          labels:
+            io.kompose.service: postgresql
+        spec:
+          containers:
+            - env:
+                - name: POSTGRES_PASSWORD
+                  value: postgres
+                - name: POSTGRES_USER
+                  value: postgres
+              image: postgres:14
+              name: postgresql
+              ports:
+                - containerPort: 5432
+              resources: {}
+              volumeMounts:
+                - mountPath: /var/lib/postgresql/data
+                  name: postgresql-claim0
+          restartPolicy: Always
+          volumes:
+            - name: postgresql-claim0
+              persistentVolumeClaim:
+                claimName: postgresql-claim0
+    status: {}
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: postgresql-claim0
+      name: postgresql-claim0
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Mi
+    status: {}
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: rest
+      name: rest
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          io.kompose.service: rest
+      strategy: {}
+      template:
+        metadata:
+          annotations:
+            kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+            kompose.version: 1.26.0 (40646f47)
+          creationTimestamp: null
+          labels:
+            io.kompose.service: rest
+        spec:
+          containers:
+            - env:
+                - name: USER_SERVICE_SERVER
+                  value: users
+              image: minerva_rest
+              imagePullPolicy: Never
+              name: rest
+              ports:
+                - containerPort: 9000
+              resources: {}
+          restartPolicy: Always
+    status: {}
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: runonce
+      name: runonce
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          io.kompose.service: runonce
+      strategy: {}
+      template:
+        metadata:
+          annotations:
+            kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+            kompose.version: 1.26.0 (40646f47)
+          creationTimestamp: null
+          labels:
+            io.kompose.service: runonce
+        spec:
+          containers:
+            - env:
+                - name: DATABASE_SERVICE_SERVER
+                  value: postgresql
+              image: minerva_runonce
+              imagePullPolicy: Never
+              name: runonce
+              ports:
+                - containerPort: 80
+              resources: {}
+          restartPolicy: Always
+    status: {}
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+        kompose.version: 1.26.0 (40646f47)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: users
+      name: users
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          io.kompose.service: users
+      strategy: {}
+      template:
+        metadata:
+          annotations:
+            kompose.cmd: kompose convert -f docker-compose.yml -o k8s-manifest.yaml
+            kompose.version: 1.26.0 (40646f47)
+          creationTimestamp: null
+          labels:
+            io.kompose.service: users
+        spec:
+          containers:
+            - env:
+                - name: DATABASE_SERVICE_SERVER
+                  value: postgresql
+              image: minerva_users
+              imagePullPolicy: Never
+              name: users
+              ports:
+                - containerPort: 9010
+              resources: {}
+          restartPolicy: Always
+    status: {}
+kind: List
+metadata: {}
+


### PR DESCRIPTION
Add initial configuration from Kubernetes.

Created from a carefully tweaked Docker Compose file using Kompose.
The Docker Compose file is, however, restored to its original state.
