### PR TITLE
Remove dependencies on `rustc-serialize`

### DIFF
--- a/minerva-data/Cargo.toml
+++ b/minerva-data/Cargo.toml
@@ -24,6 +24,6 @@ num-derive = "0.3"
 bb8 = "0.7.1"
 bb8-diesel = "0.2.1"
 sodiumoxide = ">= 0.2.7"
-chrono = {version = "0.4", features = ["serde", "rustc-serialize"]}
+chrono = {version = "0.4", features = ["serde"]}
 tokio = {version = "1", features = ["macros", "rt-multi-thread", "sync", "net"]}
 mongodb = "2.2.1"

--- a/minerva-product/Cargo.toml
+++ b/minerva-product/Cargo.toml
@@ -12,4 +12,4 @@ tokio = {version = "1", features = ["macros", "rt-multi-thread", "sync"]}
 dotenv = "0.15.0"
 tonic = "0.7"
 diesel = {version = "1.4.8", features = ["postgres", "extras", "numeric", "chrono"]}
-chrono = {version = "0.4", features = ["serde", "rustc-serialize"]}
+chrono = {version = "0.4", features = ["serde"]}

--- a/minerva-session/Cargo.toml
+++ b/minerva-session/Cargo.toml
@@ -15,6 +15,5 @@ mongodb = "2.2.1"
 futures-util = "0.3"
 base64 = "0.13.0"
 diesel = { version = "1.4.4", features = ["postgres"] }
-chrono = {version = "0.4", features = ["serde", "rustc-serialize"]}
-
+chrono = {version = "0.4", features = ["serde"]}
 

--- a/minerva-stock/Cargo.toml
+++ b/minerva-stock/Cargo.toml
@@ -11,4 +11,4 @@ minerva-data = {path = "../minerva-data"}
 tokio = {version = "1", features = ["macros", "rt-multi-thread", "sync"]}
 dotenv = "0.15.0"
 diesel = {version = "1.4.8", features = ["postgres", "extras", "numeric", "chrono"]}
-chrono = {version = "0.4", features = ["serde", "rustc-serialize"]}
+chrono = {version = "0.4", features = ["serde"]}

--- a/minerva-user/Cargo.toml
+++ b/minerva-user/Cargo.toml
@@ -15,4 +15,4 @@ diesel = { version = "1.4.4", features = ["postgres"] }
 bb8 = "0.7.1"
 bb8-diesel = "0.2.1"
 futures-util = "0.3"
-chrono = {version = "0.4", features = ["serde", "rustc-serialize"]}
+chrono = {version = "0.4", features = ["serde"]}


### PR DESCRIPTION
This fixes a Dependabot security issue with respect to `rustc-serialize` usage.