### PR TITLE
Renomeia microsserviço `USERS` para `USER`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/spec/v2.0.
 
 Relação de versões de microsserviços:
 
-- `USERS` - v0.2.1
+- `USER` - v0.2.2
 - `SESSION` - v0.1.1
 - `RUNONCE` - v0.2.1
-- `REST` - v0.2.1
+- `REST` - v0.2.2
 - Front-End - v0.1.1 (pré-alfa)
 
 #### Adicionado
@@ -33,7 +33,8 @@ Relação de versões de microsserviços:
 - Dependência da _crate_ `rustc-serialize` na configuração da _crate_
   `chrono` (em confirmidade com alerta Dependabot), para todos os módulos.
 
-### `REST` - v0.2.1
+
+### `REST` - v0.2.2
 
 #### Adicionado
 
@@ -44,6 +45,13 @@ Relação de versões de microsserviços:
 - Erros na conexão com um microsserviço agora retornam um erro 503 (Recurso
   Indisponível).
 
+
+### `USER` - v0.2.2
+
+#### Modificado
+
+- Alteração do nome do serviço de `USERS` para `USER`, evitando maiores
+  enganos.
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "minerva-rest"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dotenv",
  "minerva-data",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "minerva-rpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dotenv",
  "prost",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "minerva-user"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bb8",
  "bb8-diesel",

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,7 +35,7 @@ ENV SESSION_SERVICE_PORT=9011
 ENV PRODUCT_SERVICE_PORT=9012
 ENV STOCK_SERVICE_PORT=9013
 ENV REPORT_SERVICE_PORT=9014
-ENV USER_SERVICE_SERVER=users
+ENV USER_SERVICE_SERVER=user
 ENV SESSION_SERVICE_SERVER=session
 ENV DATABASE_SERVICE_SERVER=postgresql
 ENV MONGO_SERVICE_SERVER=mongodb
@@ -70,8 +70,8 @@ COPY --from=builder /minerva/target/release/minerva-session ./minerva-session
 CMD ["./minerva-session"]
 
 
-# USERS
-FROM deploy AS minerva_users
+# USER
+FROM deploy AS minerva_user
 EXPOSE 9010
 COPY ./tenancy.toml ./tenancy.toml
 COPY --from=builder /minerva/target/release/minerva-user ./minerva-user

--- a/deploy/rest-deployment.yml
+++ b/deploy/rest-deployment.yml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: rest-container
-          image: luksamuk/minerva_rest:0.2.1
+          image: luksamuk/minerva_rest:0.2.2
           ports:
             - containerPort: 9000
           envFrom:

--- a/deploy/servers-configmap.yml
+++ b/deploy/servers-configmap.yml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: servers-configmap
 data:
-  USER_SERVICE_SERVER: users-svc
+  USER_SERVICE_SERVER: user-svc
   SESSION_SERVICE_SERVER: session-svc
   DATABASE_SERVICE_SERVER: postgresql-svc
   MONGO_SERVICE_SERVER: mongodb-svc

--- a/deploy/stress_test.sh
+++ b/deploy/stress_test.sh
@@ -4,11 +4,11 @@ function usage() {
     echo "Uso: ./stress_test.sh <endpoint> <tipo>"
     echo "Onde <endpoint> é o caminho para a API (ex. minerva-system.io/api)"
     echo "e <tipo> é um dos possíveis sistemas:"
-    echo "  - users"
+    echo "  - user"
     echo "  - session"
     echo
     echo "Exemplo:"
-    echo "   ./stress_test.sh minerva-system.io/api users"
+    echo "   ./stress_test.sh minerva-system.io/api user"
     echo
 }
 
@@ -23,7 +23,7 @@ TEST_TYPE=$2
 TENANT=teste
 SESSION_STRESS_LOGIN_URL="http://${SERVER}/${TENANT}/login"
 SESSION_STRESS_LOGOUT_URL="http://${SERVER}/logout"
-USER_STRESS_URL="http://${SERVER}/users/1"
+USER_STRESS_URL="http://${SERVER}/user/1"
 COOKIE_FILE=/tmp/minerva_cookie.txt
 
 
@@ -45,7 +45,7 @@ function remove_session_cookie() {
 }
 
 
-function users_stress_test() {
+function user_stress_test() {
     get_session_cookie;
     for i in {1..10000}; do
 	curl -s -X GET $USER_STRESS_URL \
@@ -81,8 +81,8 @@ function session_stress_test() {
 
 echo 'Iniciando teste de stress. Use Ctrl+C para encerrar.'
 case $TEST_TYPE in
-    "users")
-	users_stress_test
+    "user")
+	user_stress_test
     ;;
 
     "session")

--- a/deploy/user-deployment.yml
+++ b/deploy/user-deployment.yml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: users-deployment
+  name: user-deployment
 spec:
   template:
     metadata:
-      name: users
+      name: user
       labels:
-        app: users
+        app: user
     spec:
       containers:
-        - name: users-container
-          image: luksamuk/minerva_users:0.2.1
+        - name: user-container
+          image: luksamuk/minerva_user:0.2.2
           ports:
             - containerPort: 9010
           envFrom:
@@ -25,5 +25,5 @@ spec:
   replicas: 2
   selector:
     matchLabels:
-      app: users
+      app: user
 

--- a/deploy/user-hpa.yml
+++ b/deploy/user-hpa.yml
@@ -1,12 +1,12 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: users-hpa
+  name: user-hpa
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: users-deployment
+    name: user-deployment
   minReplicas: 2
   maxReplicas: 6
   metrics:

--- a/deploy/user-svc.yml
+++ b/deploy/user-svc.yml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: users-svc
+  name: user-svc
 spec:
   type: ClusterIP
   selector:
-    app: users
+    app: user
   ports:
     - port: 9010
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,12 @@ services:
   rest:
     image: luksamuk/minerva_rest:latest
     environment:
-      - USER_SERVICE_SERVER=users
+      - USER_SERVICE_SERVER=user
       - SESSION_SERVICE_SERVER=session
     ports:
       - 9000:9000
     depends_on:
-      - "users"
+      - "user"
     networks:
       - minerva_system
     deploy:
@@ -47,9 +47,9 @@ services:
       restart_policy:
         condition: on-failure
   
-  # USERS service
-  users:
-    image: luksamuk/minerva_users:latest
+  # USER service
+  user:
+    image: luksamuk/minerva_user:latest
     environment:
       - DATABASE_SERVICE_SERVER=postgresql
     networks:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -136,7 +136,7 @@ services:
   visualizer:
     image: dockersamples/visualizer:stable
     ports:
-      - 8080:8080
+      - 8080:8585
     stop_grace_period: 1m30s
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -21,14 +21,14 @@ services:
   
   # REST service
   rest:
-    image: luksamuk/minerva_rest:0.2.1
+    image: luksamuk/minerva_rest:0.2.2
     environment:
-      - USER_SERVICE_SERVER=users
+      - USER_SERVICE_SERVER=user
       - SESSION_SERVICE_SERVER=session
     ports:
       - 9000:9000
     depends_on:
-      - "users"
+      - "user"
     networks:
       - minerva_system
     deploy:
@@ -60,9 +60,9 @@ services:
       placement:
         constraints: [node.role == manager]
   
-  # USERS service
-  users:
-    image: luksamuk/minerva_users:0.2.1
+  # USER service
+  user:
+    image: luksamuk/minerva_user:0.2.2
     environment:
       - DATABASE_SERVICE_SERVER=postgresql
     networks:
@@ -70,7 +70,7 @@ services:
     deploy:
       mode: replicated
       replicas: 2
-      labels: [APP = USERS_SERVICE]
+      labels: [APP = USER_SERVICE]
       restart_policy:
         condition: on-failure
 

--- a/docs/src/backend.md
+++ b/docs/src/backend.md
@@ -253,7 +253,7 @@ a configuração em desenvolvimento e em produção do mesmo.
 
 | Serviço                       | Variável                  | Valor em Produção |
 |-------------------------------|---------------------------|-------------------|
-| USER                          | `USER_SERVICE_SERVER`     | `users`           |
+| USER                          | `USER_SERVICE_SERVER`     | `user`            |
 | Banco de Dados Relacional     | `DATABASE_SERVICE_SERVER` | `postgresql`      |
 | Banco de Dados Não-Relacional | `MONGO_SERVICE_SERVER`    | `mongodb`         |
 | REST                          | nenhuma                   | `rest`            |

--- a/docs/src/deploy-kubernetes.md
+++ b/docs/src/deploy-kubernetes.md
@@ -166,7 +166,7 @@ a utilização de versionamento.
 - `mongodb-deployment`: Deployment para o banco de dados MongoDB.
 - `frontend-deployment`: Deployment para o Front-End Web do sistema.
 - `rest-deployment`: Deployment para o gateway REST do sistema.
-- `users-deployment`: Deployment para o microsserviço `USERS`.
+- `user-deployment`: Deployment para o microsserviço `USER`.
 - `session-deployment`: Deployment para o microsserviço `SESSION`.
 
 Para aplicar todos os _Deployments_, execute:
@@ -191,8 +191,8 @@ _NodePort_, e estes agem também retroativamente como _ClusterIP_.
   PostgreSQL.
 - `mongodb-svc` (_ClusterIP_): Serviço para acesso interno aos pods
   MongoDB.
-- `users-svc` (_ClusterIP_): Serviço para acesso interno aos pods do
-  microsserviço USERS.
+- `user-svc` (_ClusterIP_): Serviço para acesso interno aos pods do
+  microsserviço USER.
 - `session-svc` (_ClusterIP_): Serviço para acesso interno aos pods do
   microsserviço SESSION.
 - `frontend-svc` (_LoadBalancer_): Serviço para acesso interno e externo
@@ -225,8 +225,8 @@ for f in `ls deploy/*-job.yml`; do kubectl apply -f $f; done
 
 - `rest-hpa`: Escalonador horizontal do gateway REST. Mantém entre 1 e
   15 réplicas para `rest-deployment` com uso médio de 50% do CPU alocado.
-- `users-hpa`: Escalonador horizontal do microsserviço USERS. Mantém entre
-  2 e 6 réplicas para `users-deployment` com uso médio de 65% do CPU alocado.
+- `user-hpa`: Escalonador horizontal do microsserviço USER. Mantém entre
+  2 e 6 réplicas para `user-deployment` com uso médio de 65% do CPU alocado.
 - `session-hpa`: Escalonador horizontal do microsserviço SESSION. Mantém
   entre 2 e 6 réplicas para `session-deployment` com uso médio de 65%
   do CPU alocado.
@@ -390,7 +390,7 @@ Para realizar testes de stress, use o script `deploy/stress_test.sh`.
 Você poderá testar cada sistema crucial usando um comando como este:
 
 ```bash
-./deploy/stress_test.sh minerva-system.io/api users
+./deploy/stress_test.sh minerva-system.io/api user
 ```
 
 Para maiores informações, execute o script sem argumentos.

--- a/docs/src/deploy-swarm.md
+++ b/docs/src/deploy-swarm.md
@@ -16,6 +16,25 @@ utilizado o VirtualBox para prover essa facilidade).
 - Docker Machine;
 - VirtualBox.
 
+### Instalando o Docker Machine no Linux
+
+Como o Docker Machine é uma ferramenta defasada, é necessário executar
+passos como os a seguir para instalar:
+
+```bash
+base=https://github.com/docker/machine/releases/download/v0.16.2
+curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/tmp/docker-machine
+sudo install /tmp/docker-machine /usr/local/bin/docker-machine
+```
+
+Para instalar os drivers de KVM2, caso você prefira utilizá-los:
+
+```bash
+base=https://github.com/praveenkumar/machine-kvm2-driver/releases/download/v0.11.0
+curl -L $base/docker-machine-driver-kvm2 >/tmp/docker-machine-driver-kvm2
+sudo install /tmp/docker-machine-driver-kvm2 /usr/local/bin/docker-machine-driver-kvm2
+```
+
 
 ## Reinicializando o cluster
 

--- a/docs/src/diagramas/alteracao-usuarios.md
+++ b/docs/src/diagramas/alteracao-usuarios.md
@@ -8,7 +8,7 @@
 actor       Usuário    as ator
 boundary    FrontEnd   as frontend
 boundary    API        as api
-control     USERS      as users
+control     USER      as user
 control     SESSION    as session
 collections Redis      as redis
 collections MongoDB    as mongo
@@ -45,19 +45,19 @@ deactivate session
 
 == Verificação da existência do usuário ==
 
-api      ->  users:        Requisição de alteração de usuário
-activate users
-users    ->  postgres:     Verifica se usuário já existe
+api      ->  user:        Requisição de alteração de usuário
+activate user
+user    ->  postgres:     Verifica se usuário já existe
 activate postgres
-users    <-- postgres:     Retorno com dados do usuário
+user    <-- postgres:     Retorno com dados do usuário
 
 == Alteração do usuário no banco de dados ==
 
-users    ->  postgres:     Insere dados alterados do usuário
-users    <-- postgres:     Dados do usuário recém-alterado
+user    ->  postgres:     Insere dados alterados do usuário
+user    <-- postgres:     Dados do usuário recém-alterado
 deactivate postgres
-api      <-- users:        Dados do usuário alterado
-deactivate users
+api      <-- user:        Dados do usuário alterado
+deactivate user
 
 == Retorno da API ==
 

--- a/docs/src/diagramas/cadastro-usuarios.md
+++ b/docs/src/diagramas/cadastro-usuarios.md
@@ -8,7 +8,7 @@
 actor       Usuário    as ator
 boundary    FrontEnd   as frontend
 boundary    API        as api
-control     USERS      as users
+control     USER      as user
 control     SESSION    as session
 collections Redis      as redis
 collections MongoDB    as mongo
@@ -45,19 +45,19 @@ deactivate session
 
 == Verificação de existência do usuário ==
 
-api      ->  users:        Requisição de criação de usuário
-activate users
-users    ->  postgres:     Verifica se usuário já existe
+api      ->  user:        Requisição de criação de usuário
+activate user
+user    ->  postgres:     Verifica se usuário já existe
 activate postgres
-users    <-- postgres:     Retorno vazio
+user    <-- postgres:     Retorno vazio
 
 == Criação do usuário no banco de dados ==
 
-users    ->  postgres:     Insere dados de novo usuário
-users    <-- postgres:     Dados do usuário recém-inserido
+user    ->  postgres:     Insere dados de novo usuário
+user    <-- postgres:     Dados do usuário recém-inserido
 deactivate postgres
-api      <-- users:        Dados do usuário criado
-deactivate users
+api      <-- user:        Dados do usuário criado
+deactivate user
 
 == Retorno da API ==
 

--- a/docs/src/diagramas/casos-de-uso.md
+++ b/docs/src/diagramas/casos-de-uso.md
@@ -45,7 +45,7 @@ user -- logoff
 left to right direction
 actor :Usuário do Sistema: as user
 
-package USERS {
+package USER {
 	usecase cadastro
 	usecase listagem
 	usecase consulta

--- a/docs/src/diagramas/consultar-usuarios.md
+++ b/docs/src/diagramas/consultar-usuarios.md
@@ -8,7 +8,7 @@
 actor       Usuário    as ator
 boundary    FrontEnd   as frontend
 boundary    API        as api
-control     USERS      as users
+control     USER      as user
 control     SESSION    as session
 collections Redis      as redis
 collections MongoDB    as mongo
@@ -45,14 +45,14 @@ deactivate session
 
 == Recuperação de dados de usuários ==
 
-api -> users:              Requisita dados de um usuário
-activate users
-users -> postgres:         Requisita dados de um usuário
+api -> user:              Requisita dados de um usuário
+activate user
+user -> postgres:         Requisita dados de um usuário
 activate postgres
-users <-- postgres:        Retorna dados do usuário
+user <-- postgres:        Retorna dados do usuário
 deactivate postgres
-api <-- users:             Retorna dados do usuário
-deactivate users
+api <-- user:             Retorna dados do usuário
+deactivate user
 
 == Retorno da API ==
 

--- a/docs/src/diagramas/lista-usuarios.md
+++ b/docs/src/diagramas/lista-usuarios.md
@@ -8,7 +8,7 @@
 actor       Usuário    as ator
 boundary    FrontEnd   as frontend
 boundary    API        as api
-control     USERS      as users
+control     USER      as user
 control     SESSION    as session
 collections Redis      as redis
 collections MongoDB    as mongo
@@ -45,14 +45,14 @@ deactivate session
 
 == Recuperação de dados de usuários ==
 
-api -> users:              Requisita lista de usuários
-activate users
-users -> postgres:         Requisita dados de usuários
+api -> user:              Requisita lista de usuários
+activate user
+user -> postgres:         Requisita dados de usuários
 activate postgres
-users <-- postgres:        Retorna dados de usuários
+user <-- postgres:        Retorna dados de usuários
 deactivate postgres
-api <-- users:             Retorna lista de usuários
-deactivate users
+api <-- user:             Retorna lista de usuários
+deactivate user
 
 == Retorno da API ==
 

--- a/docs/src/diagramas/login.md
+++ b/docs/src/diagramas/login.md
@@ -10,7 +10,7 @@ Isso é gerenciado pelos próprios serviços. O MongoDB fará isso através do t
 de vida da coleção para aquele banco, enquanto o Redis fará isso através do
 tempo de vida da informação quando a mesma foi colocada em cache.
 
-**TODO:** Seria mais adequado fazer com que `SESSION` requeira a `USERS` os
+**TODO:** Seria mais adequado fazer com que `SESSION` requeira a `USER` os
 dados dos usuários, ao invés de recorrer ao banco?
 
 <center>

--- a/docs/src/diagramas/remocao-usuarios.md
+++ b/docs/src/diagramas/remocao-usuarios.md
@@ -8,7 +8,7 @@
 actor       Usuário    as ator
 boundary    FrontEnd   as frontend
 boundary    API        as api
-control     USERS      as users
+control     USER      as user
 control     SESSION    as session
 collections Redis      as redis
 collections MongoDB    as mongo
@@ -46,17 +46,17 @@ deactivate session
 
 == Verificação de existência do usuário ==
 
-api   ->  users:    Requisição da remoção de usuário
-activate users
-users ->  postgres: Verifica se usuário existe
+api   ->  user:    Requisição da remoção de usuário
+activate user
+user ->  postgres: Verifica se usuário existe
 activate postgres
-users <-- postgres: Retorno com dados do usuário
+user <-- postgres: Retorno com dados do usuário
 
 == Remoção de dados de sessão ==
 
-users   ->  postgres: Trava usuário para novas sessões
-users   <-- postgres: Sucesso
-users   ->  session:  Requisita encerramento das sessões do usuário
+user   ->  postgres: Trava usuário para novas sessões
+user   <-- postgres: Sucesso
+user   ->  session:  Requisita encerramento das sessões do usuário
 activate session
 session ->  mongo:    Requisita todas as chaves de sessões do usuário
 activate mongo
@@ -68,19 +68,19 @@ session ->  redis:    Remove todas as sessões em cache através das chaves
 activate redis
 session <-- redis:    Sucesso
 deactivate redis
-users   <-- session:  Sucesso
+user   <-- session:  Sucesso
 deactivate session
 
 == Remoção do usuário ==
 
-users    -> postgres:  Requisita remoção do usuário
-users    <-- postgres: Sucesso
+user    -> postgres:  Requisita remoção do usuário
+user    <-- postgres: Sucesso
 deactivate postgres
-api      <-- users:    Sucesso
+api      <-- user:    Sucesso
 
 == Retorno da API ==
 
-deactivate users
+deactivate user
 frontend <-- api:      Retorno vazio com sucesso
 deactivate api
 ator     <-- frontend: Mensagem de sucesso e redirecionamento

--- a/docs/src/documentacao.md
+++ b/docs/src/documentacao.md
@@ -26,7 +26,7 @@ Não se esqueça de consultar estes documentos com frequência.
   Utilitário de configuração inicial do sistema durante um deploy.
 - [SESSION](./doc/minerva_session/index.html) \
   Serviço de gerenciamento de sessão de usuário.
-- [USERS](./doc/minerva_user/index.html) \
+- [USER](./doc/minerva_user/index.html) \
   Serviço de gerenciamento de usuários.
 - PRODUCT _(não implementado)_ \
   Serviço de gerenciamento de produtos.

--- a/docs/src/gerando-imagens.md
+++ b/docs/src/gerando-imagens.md
@@ -56,8 +56,8 @@ no exemplo a seguir:
 ```bash
 # Faça algo similar para cada uma das imagens
 docker image tag \
-	seu_username/minerva_users \
-	seu_username/minerva_users:0.2.0
+	seu_username/minerva_user \
+	seu_username/minerva_user:0.2.0
 ```
 
 
@@ -95,7 +95,7 @@ como essas imagens encontram-se no DockerHub (sob o _username_ `luksamuk`):
 | `frontend`   | `luksamuk/minerva_frontend:latest` |
 | `rest`       | `luksamuk/minerva_rest:latest`     |
 | `runonce`    | `luksamuk/minerva_runonce:latest`  |
-| `users`      | `luksamuk/minerva_users:latest`    |
+| `user`       | `luksamuk/minerva_user:latest`     |
 | `session`    | `luksamuk/minerva_session:latest`  |
 | `pgadmin`    | `luksamuk/minerva_pgadmin:latest`  |
 | `postgresql` | `postgres:14` (Não gerado)         |
@@ -106,9 +106,7 @@ como essas imagens encontram-se no DockerHub (sob o _username_ `luksamuk`):
 ## Subindo imagens para o DockerHub
 
 Para enviar uma imagem para o DockerHub, primeiro é necessário se certificar de
-que essa imagem possua uma _tag_ adequada. Por exemplo, supondo que acabamos de
-gerar a imagem com a _tag_ 0.2.0 para o módulo `users`:
-
+que essa imagem possua uma _tag_ adequada.
 
 Em seguida, poderemos enviar todas as tags das imagens para o DockerHub.
 
@@ -116,7 +114,7 @@ Em seguida, poderemos enviar todas as tags das imagens para o DockerHub.
 docker image push -a luksamuk/minerva_frontend
 docker image push -a luksamuk/minerva_rest
 docker image push -a luksamuk/minerva_runonce
-docker image push -a luksamuk/minerva_users
+docker image push -a luksamuk/minerva_user
 docker image push -a luksamuk/minerva_session
 docker image push -a luksamuk/minerva_pgadmin
 ```

--- a/generate_images.sh
+++ b/generate_images.sh
@@ -3,7 +3,7 @@ declare -a TARGETS=(
     "minerva_rest"
     "minerva_runonce"
     "minerva_session"
-    "minerva_users"
+    "minerva_user"
 )
 
 # Rust language targets
@@ -19,7 +19,6 @@ do
 
     # Scrape version information and use as tag
     DIRNAME=${TARGET/_/-}
-    DIRNAME=${DIRNAME/users/user} # users/user dichotomy. Should be removed!
     IMGVERSION=`awk '/^version/{print $3}' ./$DIRNAME/Cargo.toml | tr -d '"'`;
     TAGGEDIMGNAME=$IMGNAME:$IMGVERSION
 

--- a/minerva-rest/Cargo.toml
+++ b/minerva-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minerva-rest"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "REST gateway for the Minerva System"
 authors = ["Lucas S. Vieira <lucasvieira@protonmail.com>"]

--- a/minerva-rest/src/controller/user.rs
+++ b/minerva-rest/src/controller/user.rs
@@ -1,5 +1,5 @@
 //! This submodule describes routes for managing the data for a `User` entity,
-//! particularly with respect to connecting to the `USERS` gRPC service.
+//! particularly with respect to connecting to the `USER` gRPC service.
 
 use super::response;
 use crate::fairings::auth::SessionInfo;
@@ -33,7 +33,7 @@ pub fn get_endpoint() -> String {
 /// a value named `page`. If omitted, it is assumed to be `0`.
 ///
 /// Upon success, returns a list of users in JSON format, containing up to the
-/// number of users per page as defined in the `USERS` microservice.
+/// number of users per page as defined in the `USER` microservice.
 ///
 /// Furthermore, this route assumes that the authentication cookies are being
 /// passed as well.
@@ -41,9 +41,9 @@ pub fn get_endpoint() -> String {
 /// # Request examples
 ///
 /// ```bash
-/// curl -X GET 'http://localhost:9000/users' -b cookies.txt
+/// curl -X GET 'http://localhost:9000/user' -b cookies.txt
 ///
-/// curl -X GET 'http://localhost:9000/users?page=0' -b cookies.txt
+/// curl -X GET 'http://localhost:9000/user?page=0' -b cookies.txt
 /// ```
 #[get("/?<page>")]
 async fn index(session: SessionInfo, page: Option<i64>) -> Response {
@@ -55,10 +55,10 @@ async fn index(session: SessionInfo, page: Option<i64>) -> Response {
         utils::get_ip(),
         requestor.clone(),
         tenant.clone(),
-        &format!("REST::INDEX > USERS::INDEX @ {}", endpoint),
+        &format!("REST::INDEX > USER::INDEX @ {}", endpoint),
     );
 
-    let client = rpc::users::make_client(endpoint, tenant, requestor).await;
+    let client = rpc::user::make_client(endpoint, tenant, requestor).await;
     if client.is_err() {
         return Response::generate_error(client);
     }
@@ -84,7 +84,7 @@ async fn index(session: SessionInfo, page: Option<i64>) -> Response {
 /// # Request example
 ///
 /// ```bash
-/// curl -X GET 'http://localhost:9000/users/1' -b cookies.txt
+/// curl -X GET 'http://localhost:9000/user/1' -b cookies.txt
 /// ```
 #[get("/<id>")]
 async fn show(session: SessionInfo, id: i32) -> Response {
@@ -96,10 +96,10 @@ async fn show(session: SessionInfo, id: i32) -> Response {
         utils::get_ip(),
         requestor.clone(),
         tenant.clone(),
-        &format!("REST::SHOW > USERS::SHOW @ {}", endpoint),
+        &format!("REST::SHOW > USER::SHOW @ {}", endpoint),
     );
 
-    let client = rpc::users::make_client(endpoint, tenant, requestor).await;
+    let client = rpc::user::make_client(endpoint, tenant, requestor).await;
     if client.is_err() {
         return Response::generate_error(client);
     }
@@ -126,7 +126,7 @@ async fn show(session: SessionInfo, id: i32) -> Response {
 /// # Request example
 ///
 /// ```bash
-/// curl -X POST 'http://localhost:9000/users' \
+/// curl -X POST 'http://localhost:9000/user' \
 ///      -H 'Content-Type: application/json' \
 ///      -b cookies.txt
 ///      -d '{"login": "fulano", "name": "Fulano da Silva", "email": null, "password": "senha123"}'
@@ -149,10 +149,10 @@ async fn store(session: SessionInfo, body: Json<data::user::RecvUser>) -> Respon
         utils::get_ip(),
         requestor.clone(),
         tenant.clone(),
-        &format!("REST::STORE > USERS::STORE @ {}", endpoint),
+        &format!("REST::STORE > USER::STORE @ {}", endpoint),
     );
 
-    let client = rpc::users::make_client(endpoint, tenant, requestor).await;
+    let client = rpc::user::make_client(endpoint, tenant, requestor).await;
     if client.is_err() {
         return Response::generate_error(client);
     }
@@ -181,7 +181,7 @@ async fn store(session: SessionInfo, body: Json<data::user::RecvUser>) -> Respon
 /// # Request example
 ///
 /// ```bash
-/// curl -X PUT 'http://localhost:9000/users/2' \
+/// curl -X PUT 'http://localhost:9000/user/2' \
 ///      -H 'Content-Type: application/json' \
 ///      -b cookies.txt
 ///      -d '{"login": "fulano", "name": "Fulano da Silva", "email": null, "password": null}'
@@ -196,10 +196,10 @@ async fn update(session: SessionInfo, id: i32, body: Json<data::user::RecvUser>)
         utils::get_ip(),
         requestor.clone(),
         tenant.clone(),
-        &format!("REST::UPDATE > USERS::UPDATE @ {}", endpoint),
+        &format!("REST::UPDATE > USER::UPDATE @ {}", endpoint),
     );
 
-    let client = rpc::users::make_client(endpoint, tenant, requestor).await;
+    let client = rpc::user::make_client(endpoint, tenant, requestor).await;
     if client.is_err() {
         return Response::generate_error(client);
     }
@@ -226,7 +226,7 @@ async fn update(session: SessionInfo, id: i32, body: Json<data::user::RecvUser>)
 /// # Request example
 ///
 /// ```bash
-/// curl -X DELETE 'http://localhost:9000/users/2' -b cookies.txt
+/// curl -X DELETE 'http://localhost:9000/user/2' -b cookies.txt
 /// ```
 #[delete("/<index>")]
 async fn delete(session: SessionInfo, index: i32) -> Response {
@@ -238,10 +238,10 @@ async fn delete(session: SessionInfo, index: i32) -> Response {
         utils::get_ip(),
         requestor.clone(),
         tenant.clone(),
-        &format!("REST::DELETE > USERS::DELETE @ {}", endpoint),
+        &format!("REST::DELETE > USER::DELETE @ {}", endpoint),
     );
 
-    let client = rpc::users::make_client(endpoint, tenant, requestor).await;
+    let client = rpc::user::make_client(endpoint, tenant, requestor).await;
     if client.is_err() {
         return Response::generate_error(client);
     }

--- a/minerva-rest/src/main.rs
+++ b/minerva-rest/src/main.rs
@@ -37,5 +37,5 @@ fn launch() -> rocket::Rocket<rocket::Build> {
     rocket::build()
         .register("/", controller::handlers::catchers())
         .mount("/", controller::auth::routes())
-        .mount("/users", controller::user::routes())
+        .mount("/user", controller::user::routes())
 }

--- a/minerva-rest/src/tests.rs
+++ b/minerva-rest/src/tests.rs
@@ -74,7 +74,7 @@ impl Microservices {
                 .map(|name| {
                     let service = match *name {
                         "TENANCY" => "minerva-tenancy",
-                        "USERS" => "minerva-user",
+                        "USER" => "minerva-user",
                         "SESSION" => "minerva-session",
                         "PRODUCT" => "minerva-product",
                         "STOCK" => "minerva-stock",
@@ -154,14 +154,14 @@ fn login_logout() {
     svc.dispose();
 }
 
-/* Users API */
+/* User API */
 
 #[test]
 #[serial]
 fn get_user_data() {
     use minerva_data::user::User;
 
-    let mut svc = Microservices::spawn(vec!["SESSION", "USERS"]);
+    let mut svc = Microservices::spawn(vec!["SESSION", "USER"]);
     let client = make_client();
 
     // Login
@@ -178,7 +178,7 @@ fn get_user_data() {
     assert_eq!(response.status(), Status::Ok);
 
     // Get users
-    let response: LocalResponse = client.get("/users").dispatch();
+    let response: LocalResponse = client.get("/user").dispatch();
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.content_type(), Some(ContentType::JSON));
 
@@ -194,7 +194,7 @@ fn get_user_data() {
 
     // Get single user: the same administrator found before
     let id = user.id;
-    let response = client.get(format!("/users/{}", id)).dispatch();
+    let response = client.get(format!("/user/{}", id)).dispatch();
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.content_type(), Some(ContentType::JSON));
 
@@ -215,7 +215,7 @@ fn get_user_data() {
 fn crud_user() {
     use minerva_data::user::User;
 
-    let mut svc = Microservices::spawn(vec!["SESSION", "USERS"]);
+    let mut svc = Microservices::spawn(vec!["SESSION", "USER"]);
     let client = make_client();
 
     // Login
@@ -233,7 +233,7 @@ fn crud_user() {
 
     // Create user
     let response = client
-        .post("/users")
+        .post("/user")
         .body(
             json!({
             "login": "fulano_teste_rest",
@@ -254,7 +254,7 @@ fn crud_user() {
 
     // Fetch user as inserted
     let id = user.id;
-    let response = client.get(format!("/users/{}", id)).dispatch();
+    let response = client.get(format!("/user/{}", id)).dispatch();
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.content_type(), Some(ContentType::JSON));
 
@@ -265,7 +265,7 @@ fn crud_user() {
 
     // Update user data
     let response = client
-        .put(format!("/users/{}", id))
+        .put(format!("/user/{}", id))
         .body(
             json!({
                 "login": user.login.clone(),
@@ -284,7 +284,7 @@ fn crud_user() {
     assert_eq!(user.email, Some("fulano@exemplo.com".into()));
 
     // Fetch modified user again
-    let response = client.get(format!("/users/{}", id)).dispatch();
+    let response = client.get(format!("/user/{}", id)).dispatch();
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.content_type(), Some(ContentType::JSON));
 
@@ -294,7 +294,7 @@ fn crud_user() {
     assert_eq!(user.email, Some("fulano@exemplo.com".into()));
 
     // Remove user
-    let response = client.delete(format!("/users/{}", id)).dispatch();
+    let response = client.delete(format!("/user/{}", id)).dispatch();
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.content_type(), Some(ContentType::JSON));
     assert_eq!(response.into_string(), Some("{}".into()));
@@ -335,7 +335,7 @@ fn failed_requests() {
     assert_eq!(response.cookies().get_private("token"), None);
 
     // Create microservices
-    let mut svc = Microservices::spawn(vec!["SESSION", "USERS"]);
+    let mut svc = Microservices::spawn(vec!["SESSION", "USER"]);
 
     // 422 for a malformed login request
     let response = client
@@ -351,7 +351,7 @@ fn failed_requests() {
     assert_eq!(response.content_type(), Some(ContentType::JSON));
 
     // 401 for attempting to list users without logging in
-    let response = client.get("/users").dispatch();
+    let response = client.get("/user").dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
     assert_eq!(response.content_type(), Some(ContentType::JSON));
 
@@ -370,7 +370,7 @@ fn failed_requests() {
 
     // 422 for a malformed user creation request
     let response = client
-        .post("/users")
+        .post("/user")
         .body(
             json!({
                 "name": "Fulano da Silva",

--- a/minerva-rpc/Cargo.toml
+++ b/minerva-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minerva-rpc"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Remote Procedure Call library for the Minerva System"
 authors = ["Lucas S. Vieira <lucasvieira@protonmail.com>"]

--- a/minerva-rpc/build.rs
+++ b/minerva-rpc/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     let files = [
         "./proto/messages.proto",
-        "./proto/users.proto",
+        "./proto/user.proto",
         "./proto/products.proto",
         "./proto/session.proto",
     ];

--- a/minerva-rpc/proto/user.proto
+++ b/minerva-rpc/proto/user.proto
@@ -6,7 +6,7 @@ import "google/protobuf/empty.proto";
 
 package User;
 
-service Users {
+service User {
   // List all users, given a page index.
   rpc index(Messages.PageIndex) returns (Messages.UserList) {}
 

--- a/minerva-rpc/src/lib.rs
+++ b/minerva-rpc/src/lib.rs
@@ -20,4 +20,4 @@ pub mod messages;
 pub mod metadata;
 pub mod products;
 pub mod session;
-pub mod users;
+pub mod user;

--- a/minerva-rpc/src/user.rs
+++ b/minerva-rpc/src/user.rs
@@ -33,5 +33,5 @@ pub async fn make_client(
                 ClientInterceptor::new(&tenant, &requestor),
             )
         })
-        .map_err(|e| Status::unavailable(format!("Error connecting to USERS service: {}", e)))
+        .map_err(|e| Status::unavailable(format!("Error connecting to USER service: {}", e)))
 }

--- a/minerva-rpc/src/user.rs
+++ b/minerva-rpc/src/user.rs
@@ -1,4 +1,4 @@
-//! Structures and algorithms related to a server and a client for the Users
+//! Structures and algorithms related to a server and a client for the User
 //! service.
 
 tonic::include_proto!("user");
@@ -8,12 +8,12 @@ use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
 use tonic::Status;
 
-/// Type for a `UsersClient` with an interceptor that sends tenant and
+/// Type for a `UserClient` with an interceptor that sends tenant and
 /// requestor metadata to the server.
-pub type UsersInterceptedClient =
-    users_client::UsersClient<InterceptedService<Channel, ClientInterceptor>>;
+pub type UserInterceptedClient =
+    user_client::UserClient<InterceptedService<Channel, ClientInterceptor>>;
 
-/// Creates a Users client with tenant and requestor metadata and connects
+/// Creates a User client with tenant and requestor metadata and connects
 /// to the server. Upon failure, returns an `Unavailable` gRPC status.
 ///
 /// This function requires information about `tenant`, `requestor` and the
@@ -22,13 +22,13 @@ pub async fn make_client(
     endpoint: String,
     tenant: String,
     requestor: String,
-) -> Result<UsersInterceptedClient, Status> {
+) -> Result<UserInterceptedClient, Status> {
     Channel::from_shared(endpoint.clone())
         .unwrap()
         .connect()
         .await
         .map(|channel| {
-            users_client::UsersClient::with_interceptor(
+            user_client::UserClient::with_interceptor(
                 channel,
                 ClientInterceptor::new(&tenant, &requestor),
             )

--- a/minerva-user/Cargo.toml
+++ b/minerva-user/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minerva-user"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "User management microservice for the Minerva System"
 authors = ["Lucas S. Vieira <lucasvieira@protonmail.com>"]

--- a/minerva-user/src/main.rs
+++ b/minerva-user/src/main.rs
@@ -1,4 +1,4 @@
-//! # Minerva System: USERS Service
+//! # Minerva System: USER Service
 //!
 //! ## About this service
 //! This service's responsibility is that of managing anything related to users,
@@ -15,7 +15,7 @@ extern crate diesel;
 
 use dotenv::dotenv;
 use minerva_data::{db, encryption};
-use minerva_rpc::users::users_server::UsersServer;
+use minerva_rpc::user::user_server::UserServer;
 use std::collections::HashMap;
 use std::env;
 use tonic::transport::Server;
@@ -28,7 +28,7 @@ mod tests;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Minerva System: USERS service");
+    println!("Minerva System: USER service");
     println!("Copyright (c) 2022 Lucas S. Vieira");
     println!();
     dotenv().ok();
@@ -57,11 +57,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Starting USER on {}...", addr);
 
     let server = Server::builder()
-        .add_service(UsersServer::new(service::UsersService { pools }))
+        .add_service(UserServer::new(service::UserService { pools }))
         .serve(addr);
 
-    println!("USERS is ready to accept connections.");
+    println!("USER is ready to accept connections.");
     server.await?;
-    println!("USERS shut down.");
+    println!("USER shut down.");
     Ok(())
 }

--- a/minerva-user/src/repository.rs
+++ b/minerva-user/src/repository.rs
@@ -48,7 +48,7 @@ pub fn add_user(
 
             diesel::insert_into(syslog::table)
                 .values(&NewLog {
-                    service: "USERS".to_string(),
+                    service: "USER".to_string(),
                     requestor,
                     entity: "user".to_string(),
                     operation: OpType::Insert,
@@ -105,7 +105,7 @@ pub fn update_user(
 
             diesel::insert_into(syslog::table)
                 .values(&NewLog {
-                    service: "USERS".to_string(),
+                    service: "USER".to_string(),
                     requestor,
                     entity: "user".to_string(),
                     operation: OpType::Update,
@@ -137,7 +137,7 @@ pub fn delete_user(
 
             diesel::insert_into(syslog::table)
                 .values(&NewLog {
-                    service: "USERS".to_string(),
+                    service: "USER".to_string(),
                     requestor,
                     entity: "user".to_string(),
                     operation: OpType::Delete,

--- a/minerva-user/src/service.rs
+++ b/minerva-user/src/service.rs
@@ -1,23 +1,23 @@
-//! This module contains the actual implementation for the `Users` gRPC service.
+//! This module contains the actual implementation for the `User` gRPC service.
 
 use crate::repository;
 use minerva_data as lib_data;
 use minerva_data::db::DBPool;
 use minerva_rpc as lib_rpc;
-use minerva_rpc::users::users_server::Users;
+use minerva_rpc::user::user_server::User;
 use minerva_rpc::{messages, metadata};
 use std::collections::HashMap;
 use tonic::{Request, Response, Status};
 
 /// Represents a gRPC service for users.
 #[derive(Clone)]
-pub struct UsersService {
+pub struct UserService {
     /// Holds database connection pools for all tenants.
     pub pools: HashMap<String, DBPool>,
 }
 
 #[tonic::async_trait]
-impl Users for UsersService {
+impl User for UserService {
     async fn index(
         &self,
         req: Request<messages::PageIndex>,

--- a/minerva-user/src/service.rs
+++ b/minerva-user/src/service.rs
@@ -9,7 +9,7 @@ use minerva_rpc::{messages, metadata};
 use std::collections::HashMap;
 use tonic::{Request, Response, Status};
 
-/// Represents a gRPC service for users.
+/// Represents a gRPC service for user.
 #[derive(Clone)]
 pub struct UserService {
     /// Holds database connection pools for all tenants.
@@ -32,7 +32,7 @@ impl User for UserService {
             lib_rpc::get_address(&req),
             requestor.clone(),
             tenant.clone(),
-            "USERS::INDEX",
+            "USER::INDEX",
         );
 
         let page = req.into_inner().index.unwrap_or(0);
@@ -67,7 +67,7 @@ impl User for UserService {
             lib_rpc::get_address(&req),
             requestor.clone(),
             tenant.clone(),
-            "USERS::SHOW",
+            "USER::SHOW",
         );
 
         let result = {
@@ -104,7 +104,7 @@ impl User for UserService {
             lib_rpc::get_address(&req),
             requestor.clone(),
             tenant.clone(),
-            "USERS::STORE",
+            "USER::STORE",
         );
 
         let result = {
@@ -140,7 +140,7 @@ impl User for UserService {
             lib_rpc::get_address(&req),
             requestor.clone(),
             tenant.clone(),
-            "USERS::UPDATE",
+            "USER::UPDATE",
         );
 
         let result = {
@@ -173,7 +173,7 @@ impl User for UserService {
             lib_rpc::get_address(&req),
             requestor.clone(),
             tenant.clone(),
-            "USERS::DELETE",
+            "USER::DELETE",
         );
 
         let result = {

--- a/minerva-user/src/tests.rs
+++ b/minerva-user/src/tests.rs
@@ -55,7 +55,7 @@ async fn make_test_server(
 
     let client = minerva_rpc::user::make_client(endpoint, "minerva".into(), "tester".into())
         .await
-        .expect("Successfull connection to USERS gRPC client");
+        .expect("Successfull connection to USER gRPC client");
 
     (handle, client, tx)
 }

--- a/minerva-user/src/tests.rs
+++ b/minerva-user/src/tests.rs
@@ -5,8 +5,8 @@ use minerva_data::user as model;
 use minerva_data::{db, encryption};
 use minerva_rpc::messages;
 use minerva_rpc::metadata::ClientInterceptor;
-use minerva_rpc::users::users_client::UsersClient;
-use minerva_rpc::users::users_server::UsersServer;
+use minerva_rpc::user::user_client::UserClient;
+use minerva_rpc::user::user_server::UserServer;
 use std::collections::HashMap;
 use std::env;
 use std::time::Duration;
@@ -20,7 +20,7 @@ async fn make_test_server(
     port: u32,
 ) -> (
     JoinHandle<()>,
-    UsersClient<InterceptedService<Channel, ClientInterceptor>>,
+    UserClient<InterceptedService<Channel, ClientInterceptor>>,
     oneshot::Sender<()>,
 ) {
     encryption::init_hasher();
@@ -45,7 +45,7 @@ async fn make_test_server(
     // Spawn server on a concurrent task
     let handle = tokio::spawn(async move {
         Server::builder()
-            .add_service(UsersServer::new(service::UsersService { pools }))
+            .add_service(UserServer::new(service::UserService { pools }))
             .serve_with_shutdown(address, rx.map(drop))
             .await
             .unwrap();
@@ -53,7 +53,7 @@ async fn make_test_server(
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let client = minerva_rpc::users::make_client(endpoint, "minerva".into(), "tester".into())
+    let client = minerva_rpc::user::make_client(endpoint, "minerva".into(), "tester".into())
         .await
         .expect("Successfull connection to USERS gRPC client");
 

--- a/push_images.sh
+++ b/push_images.sh
@@ -3,6 +3,6 @@
 docker image push -a luksamuk/minerva_frontend
 docker image push -a luksamuk/minerva_rest
 docker image push -a luksamuk/minerva_runonce
-docker image push -a luksamuk/minerva_users
+docker image push -a luksamuk/minerva_user
 docker image push -a luksamuk/minerva_session
 docker image push -a luksamuk/minerva_pgadmin


### PR DESCRIPTION
Closes #22.

- Modify service `USERS` naming to `USER` (protobufs and RPC)
- Modify service `USERS` naming to `USER` (`USER` service)
- Modify service `USERS` naming to `USER` (`REST` service)
- Modify service `USERS` naming to `USER` (`USER` docs and logs)
- Modify service `USERS` naming to `USER` (Dockerfile and image build)
- Modify service `USERS` naming to `USER` (Compose and Stack config)
- Modify service `USERS` naming to `USER` (Kubernetes config)
- Add documentation for installing Docker Machine on Linux
- Fix deploy port for Docker Stack / Swarm method
- Fix a problem on the creation of REST deployment for Kubernetes
- Fixes on official documentation
- Update CHANGELOG.md
- Last changes for renaming service `USERS` to `USER`
