### PR TITLE
Adoção da biblioteca `Argon2` em detrimento da `sodiumoxide` para hash de senhas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "argon2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27e27b63e4a34caee411ade944981136fdfa535522dc9944d6700196cbd899f"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "password-hash",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64ct"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
+
+[[package]]
 name = "bb8"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +235,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -518,15 +544,6 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
-name = "ed25519"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
-dependencies = [
- "signature",
-]
 
 [[package]]
 name = "either"
@@ -996,18 +1013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
-name = "libsodium-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "walkdir",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1138,7 @@ version = "0.0.0"
 name = "minerva-data"
 version = "0.2.1"
 dependencies = [
+ "argon2",
  "bb8",
  "bb8-diesel",
  "bigdecimal",
@@ -1144,11 +1150,11 @@ dependencies = [
  "mongodb",
  "num-derive",
  "num-traits",
+ "rand_core",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_repr",
- "sodiumoxide",
  "tokio",
  "toml",
 ]
@@ -1474,6 +1480,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e029e94abc8fb0065241c308f1ac6bc8d20f450e8f7c5f0b25cd9b8d526ba294"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,12 +1569,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polyval"
@@ -1975,15 +1986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,12 +2172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
-
-[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,18 +2191,6 @@ checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "sodiumoxide"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
-dependencies = [
- "ed25519",
- "libc",
- "libsodium-sys",
- "serde",
 ]
 
 [[package]]
@@ -2819,17 +2803,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
-]
-
-[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,15 +2939,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/minerva-data/Cargo.toml
+++ b/minerva-data/Cargo.toml
@@ -23,7 +23,8 @@ num-traits = "0.2"
 num-derive = "0.3"
 bb8 = "0.7.1"
 bb8-diesel = "0.2.1"
-sodiumoxide = ">= 0.2.7"
 chrono = {version = "0.4", features = ["serde"]}
 tokio = {version = "1", features = ["macros", "rt-multi-thread", "sync", "net"]}
 mongodb = "2.2.1"
+argon2 = "0.4"
+rand_core = {version = "0.6", features = ["std"]}

--- a/minerva-data/src/encryption.rs
+++ b/minerva-data/src/encryption.rs
@@ -1,11 +1,9 @@
 //! This module wraps functions related to password encryption.
 
-use sodiumoxide::crypto::pwhash::argon2id13;
-
-/// Initialize password hasher.
-pub fn init_hasher() {
-    sodiumoxide::init().unwrap();
-}
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2,
+};
 
 /// Generate a hash from a slice. Returns the actual bytes of
 /// the hashing process. If the hash cannot be generated, panics.
@@ -13,21 +11,21 @@ pub fn init_hasher() {
 /// To have this function work properly, one should call `init_hasher`
 /// when initializing whathever module or test this function is used on.
 pub fn generate_hash(password: &str) -> Vec<u8> {
-    argon2id13::pwhash(
-        password.as_bytes(),
-        argon2id13::OPSLIMIT_INTERACTIVE,
-        argon2id13::MEMLIMIT_INTERACTIVE,
-    )
-    .expect("Cannot generate hash from string")
-    .0
-    .to_vec()
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+    argon2
+        .hash_password(password.as_bytes(), &salt)
+        .expect("Cannot generate hash from string")
+        .to_string()
+        .as_bytes()
+        .to_vec()
 }
 
 /// Check whether a given password matches a given generated hash.
 /// Use this function for password authentication.
-pub fn check_hash(password: &str, hash: &[u8]) -> bool {
-    match argon2id13::HashedPassword::from_slice(hash) {
-        Some(pwhash) => argon2id13::pwhash_verify(&pwhash, password.as_bytes()),
-        None => false,
-    }
+pub fn check_hash(password: &str, hash: &str) -> bool {
+    let parsed_hash = PasswordHash::new(hash).expect("Cannot parse password hash");
+    Argon2::default()
+        .verify_password(password.as_bytes(), &parsed_hash)
+        .is_ok()
 }

--- a/minerva-data/src/user.rs
+++ b/minerva-data/src/user.rs
@@ -4,6 +4,7 @@
 use crate::encryption;
 use crate::schema::user;
 use minerva_rpc::messages;
+use std::str;
 
 /// DTO representing a single entry on the `user` table.
 #[derive(Queryable, Serialize, Deserialize, Clone, Debug)]
@@ -148,11 +149,10 @@ pub fn vec_to_message(v: Vec<User>) -> messages::UserList {
 mod unit_tests {
     use super::*;
     use crate::encryption;
+    use std::str;
 
     #[test]
     fn convert_message_to_user() {
-        encryption::init_hasher();
-
         let user = User {
             id: 0,
             login: "teste".into(),
@@ -172,14 +172,18 @@ mod unit_tests {
         let msg_user: User = msg.into();
 
         assert_eq!(user, msg_user);
-        assert!(encryption::check_hash("senha", &user.pwhash));
-        assert!(encryption::check_hash("senha", &msg_user.pwhash));
+        assert!(encryption::check_hash(
+            "senha",
+            str::from_utf8(&user.pwhash).unwrap()
+        ));
+        assert!(encryption::check_hash(
+            "senha",
+            str::from_utf8(&msg_user.pwhash).unwrap()
+        ));
     }
 
     #[test]
     fn convert_user_to_message() {
-        encryption::init_hasher();
-
         let msg = messages::User {
             id: Some(0),
             login: "ciclano".into(),
@@ -202,14 +206,15 @@ mod unit_tests {
         assert_eq!(msg.login, expected_msg.login);
         assert_eq!(msg.name, expected_msg.name);
         assert_eq!(msg.email, expected_msg.email);
-        assert!(encryption::check_hash("senha123", &expected.pwhash));
+        assert!(encryption::check_hash(
+            "senha123",
+            str::from_utf8(&expected.pwhash).unwrap()
+        ));
         assert!(expected_msg.password.is_none());
     }
 
     #[test]
     fn convert_message_to_newuser() {
-        encryption::init_hasher();
-
         let newuser = NewUser {
             login: "teste".into(),
             name: "Fulano da Silva".into(),
@@ -228,8 +233,14 @@ mod unit_tests {
         let msg_user: NewUser = msg.into();
 
         assert_eq!(newuser, msg_user);
-        assert!(encryption::check_hash("senha", &newuser.pwhash));
-        assert!(encryption::check_hash("senha", &msg_user.pwhash));
+        assert!(encryption::check_hash(
+            "senha",
+            str::from_utf8(&newuser.pwhash).unwrap()
+        ));
+        assert!(encryption::check_hash(
+            "senha",
+            str::from_utf8(&msg_user.pwhash).unwrap()
+        ));
     }
 
     #[test]
@@ -290,8 +301,6 @@ mod unit_tests {
 
     #[test]
     fn convert_userlist_message_to_user_vec() {
-        encryption::init_hasher();
-
         let mut msg = messages::UserList {
             users: vec![
                 messages::User {
@@ -351,19 +360,17 @@ mod unit_tests {
             assert_eq!(converted, expected);
             assert!(encryption::check_hash(
                 message.password.as_ref().unwrap(),
-                &expected.pwhash
+                str::from_utf8(&expected.pwhash).unwrap()
             ));
             assert!(encryption::check_hash(
                 message.password.as_ref().unwrap(),
-                &converted.pwhash
+                str::from_utf8(&converted.pwhash).unwrap()
             ));
         }
     }
 
     #[test]
     fn convert_user_vec_to_userlist_message() {
-        encryption::init_hasher();
-
         let users: Vec<User> = vec![
             User {
                 id: 1,

--- a/minerva-product/src/main.rs
+++ b/minerva-product/src/main.rs
@@ -12,7 +12,6 @@
 #![warn(missing_docs)]
 
 use dotenv::dotenv;
-use minerva_data::encryption;
 use minerva_rpc::products::products_server::ProductsServer;
 use std::env;
 use tonic::transport::Server;
@@ -29,7 +28,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
     let port = env::var("PRODUCT_SERVICE_PORT").expect("Unable to read PRODUCT_SERVICE_PORT");
     let addr = format!("0.0.0.0:{}", port).parse()?;
-    encryption::init_hasher();
 
     println!("Starting PRODUCT on {}...", addr);
 

--- a/minerva-session/src/main.rs
+++ b/minerva-session/src/main.rs
@@ -14,7 +14,7 @@
 #![warn(missing_docs)]
 
 use dotenv::dotenv;
-use minerva_data::{db, encryption, mongo};
+use minerva_data::{db, mongo};
 use minerva_rpc::session::session_server::SessionServer;
 use std::collections::HashMap;
 use std::env;
@@ -33,7 +33,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     dotenv().ok();
-    encryption::init_hasher();
 
     let port = env::var("SESSION_SERVICE_PORT").expect("Unable to read SESSION_SERVICE_PORT");
     let dbserver =

--- a/minerva-session/src/repository.rs
+++ b/minerva-session/src/repository.rs
@@ -10,6 +10,7 @@ use minerva_data::user::User;
 use mongodb::bson::doc;
 use mongodb::bson::oid::ObjectId;
 use mongodb::Database;
+use std::str;
 use tonic::Status;
 
 /// Creates a new session for a user. Given the data for a new session, checks
@@ -35,7 +36,9 @@ pub async fn create_session(
     .map_err(|_| Status::unauthenticated("Invalid login or password"))?;
 
     // Check for correct password
-    if !encryption::check_hash(&data.password, &usr.pwhash) {
+    let pwhash = str::from_utf8(&usr.pwhash)
+        .map_err(|e| Status::internal(format!("Error while performing authentication: {}", e)))?;
+    if !encryption::check_hash(&data.password, pwhash) {
         return Err(Status::unauthenticated("Invalid login or password"));
     }
 

--- a/minerva-user/src/main.rs
+++ b/minerva-user/src/main.rs
@@ -14,7 +14,7 @@ extern crate bb8_diesel;
 extern crate diesel;
 
 use dotenv::dotenv;
-use minerva_data::{db, encryption};
+use minerva_data::db;
 use minerva_rpc::user::user_server::UserServer;
 use std::collections::HashMap;
 use std::env;
@@ -52,7 +52,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = env::var("USER_SERVICE_PORT").expect("Unable to read USER_SERVICE_PORT");
     let addr = format!("0.0.0.0:{}", port).parse()?;
-    encryption::init_hasher();
 
     println!("Starting USER on {}...", addr);
 

--- a/minerva-user/src/tests.rs
+++ b/minerva-user/src/tests.rs
@@ -1,8 +1,8 @@
 use crate::service;
 use dotenv::dotenv;
 use futures_util::FutureExt;
+use minerva_data::db;
 use minerva_data::user as model;
-use minerva_data::{db, encryption};
 use minerva_rpc::messages;
 use minerva_rpc::metadata::ClientInterceptor;
 use minerva_rpc::user::user_client::UserClient;
@@ -23,7 +23,6 @@ async fn make_test_server(
     UserClient<InterceptedService<Channel, ClientInterceptor>>,
     oneshot::Sender<()>,
 ) {
-    encryption::init_hasher();
     dotenv().ok();
 
     // Generate server address and client endpoint


### PR DESCRIPTION
Closes #28.

Essa modificação foi realizada por questões de segurança, e com possibilidade de sanar #29 também.
