### PR TITLE
Modifica imagens Docker para usar Alpine em vez de Debian

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,15 +1,19 @@
-FROM rust:1.61.0 AS rust_base
+## Compilation and preparation
+
+# Base container for compilation
+FROM rust:1.61.0-alpine3.15 AS rust_base
 WORKDIR /
-RUN apt update && apt install -y cmake
+RUN apk add --no-cache cmake make musl-dev file build-base libpq libpq-dev
 RUN cargo install cargo-chef
 
+# Cargo Chef recipe generation
 FROM rust_base AS chef
 RUN mkdir /minerva
 WORKDIR /minerva
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-
+# Build all modules
 FROM rust_base AS builder
 RUN mkdir /minerva
 WORKDIR /minerva
@@ -18,16 +22,15 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release
 
-FROM debian:bullseye-slim AS deploy
+# Base container for deploying services
+FROM alpine:3.15 AS deploy
 ARG APP=/usr/src/app
-RUN apt update \
-    && apt install -y ca-certificates tzdata libpq5 \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates tzdata libpq
 ENV TZ=Etc/UTC \
     APP_USER=appuser
-RUN groupadd $APP_USER \
-    && useradd -g $APP_USER $APP_USER \
-    && mkdir -p ${APP}
+RUN addgroup -g 1000 $APP_USER \
+    && mkdir -p $APP \
+    && adduser -u 1000 -G $APP_USER -h $APP -D $APP_USER
 RUN chown -R $APP_USER:$APP_USER ${APP}
 USER $APP_USER
 ENV USER_SERVICE_PORT=9010
@@ -43,7 +46,7 @@ ENV ROCKET_KEEP_ALIVE=0
 ENV ROCKET_ENV=production
 WORKDIR ${APP}
 
-## Actual parts
+## Service containers
 
 # REST
 FROM deploy AS minerva_rest

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@
 # Base container for compilation
 FROM rust:1.61.0-alpine3.15 AS rust_base
 WORKDIR /
-RUN apk add --no-cache cmake make musl-dev file build-base libpq libpq-dev
+RUN apk add --no-cache cmake make musl-dev file build-base libpq libpq-dev openssl-dev postgresql-dev
 RUN cargo install cargo-chef
 
 # Cargo Chef recipe generation
@@ -20,12 +20,18 @@ WORKDIR /minerva
 COPY --from=chef /minerva/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
+ENV RUSTFLAGS="-C target-feature=-crt-static"
 RUN cargo build --release
 
 # Base container for deploying services
 FROM alpine:3.15 AS deploy
 ARG APP=/usr/src/app
 RUN apk add --no-cache ca-certificates tzdata libpq
+COPY --from=builder /usr/lib/libgcc_s.so.1 /usr/lib/
+COPY --from=builder /usr/lib/libgcc_s.so /usr/lib/
+COPY --from=builder /usr/lib/libstdc++.so.6.0.28 /usr/lib/
+COPY --from=builder /usr/lib/libstdc++.so.6 /usr/lib/
+COPY --from=builder /usr/lib/libstdc++.so /usr/lib/
 ENV TZ=Etc/UTC \
     APP_USER=appuser
 RUN addgroup -g 1000 $APP_USER \

--- a/deploy/frontend-deployment.yml
+++ b/deploy/frontend-deployment.yml
@@ -12,6 +12,7 @@ spec:
       containers:
         - name: frontend-container
           image: luksamuk/minerva_frontend:0.1.1
+          imagePullPolicy: Always
           ports:
             - containerPort: 80
           envFrom:

--- a/deploy/mongodb-deployment.yml
+++ b/deploy/mongodb-deployment.yml
@@ -12,6 +12,7 @@ spec:
       containers:
         - name: mongodb-container
           image: mongo:5
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /data/db
               name: mongodb-pv

--- a/deploy/postgresql-deployment.yml
+++ b/deploy/postgresql-deployment.yml
@@ -12,6 +12,7 @@ spec:
       containers:
         - name: postgresql-container
           image: postgres:14
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: postgresql-pv

--- a/deploy/rest-deployment.yml
+++ b/deploy/rest-deployment.yml
@@ -12,6 +12,7 @@ spec:
       containers:
         - name: rest-container
           image: luksamuk/minerva_rest:0.2.2
+          imagePullPolicy: Always
           ports:
             - containerPort: 9000
           envFrom:

--- a/deploy/runonce-job.yml
+++ b/deploy/runonce-job.yml
@@ -12,6 +12,7 @@ spec:
       containers:
         - name: runonce
           image: luksamuk/minerva_runonce:0.2.1
+          imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: runonce-configmap

--- a/deploy/session-deployment.yml
+++ b/deploy/session-deployment.yml
@@ -12,6 +12,7 @@ spec:
       containers:
         - name: session-container
           image: luksamuk/minerva_session:0.1.1
+          imagePullPolicy: Always
           ports:
             - containerPort: 9011
           envFrom:

--- a/deploy/user-deployment.yml
+++ b/deploy/user-deployment.yml
@@ -12,6 +12,7 @@ spec:
       containers:
         - name: user-container
           image: luksamuk/minerva_user:0.2.2
+          imagePullPolicy: Always
           ports:
             - containerPort: 9010
           envFrom:


### PR DESCRIPTION
Closes #29.

- Configure Dockerfile for using Alpine Linux on build and deploy
- Change `imagePullPolicy` of all deployments on Kubernetes
- Fix PostgreSQL connections not working on Alpine images
